### PR TITLE
ci(build): move prod deploys to stg temporary

### DIFF
--- a/.github/workflows/prod-pipeline.yml
+++ b/.github/workflows/prod-pipeline.yml
@@ -6,7 +6,7 @@ on:
       - master
       
 env:
-  ENV: "prd"
+  ENV: "stg"
   APP: "aepp-faucet-nodejs"
 
 jobs:
@@ -51,9 +51,7 @@ jobs:
           echo "::set-output name=git-sha::$(git rev-parse --short HEAD)"
 
       - name: Extract metadata for docker
-        if: |
-          github.event_name == 'push' ||
-          startsWith(github.ref, 'refs/tags/v')
+        if: github.event_name == 'push'
         id: meta
         uses: docker/metadata-action@v3
         with:
@@ -62,9 +60,7 @@ jobs:
             type=raw,value=latest,enable=${{ endsWith(GitHub.ref, 'master') }}
 
       - name: Build and push docker image
-        if: |
-          github.event_name == 'push' ||
-          startsWith(github.ref, 'refs/tags/v')
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -79,7 +75,7 @@ jobs:
           cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
 
       - name: Move cache
-        if: github.event_name == 'pull_request' && github.event.action == 'opened' || github.event.action == 'synchronize'
+        if: github.event_name == 'push'
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
@@ -87,7 +83,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: aeternity/gitops-apps.git
-          ref: prd
+          ref: stg
           persist-credentials: false
           fetch-depth: 0      
       
@@ -105,4 +101,4 @@ jobs:
         with:
           repository: aeternity/gitops-apps
           github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
-          branch: prd
+          branch: stg


### PR DESCRIPTION
Temporary move prod deployments to staging , as we have to migrate the ssl setup in prod to support custom domains.
Added and few other fixes ,that I missed in the prod pipeline.

Deployment should be tested , but the ssl now works here as requested : https://faucet.aepps.com/