### PR TITLE
feat: add cors

### DIFF
--- a/faucet.mjs
+++ b/faucet.mjs
@@ -6,6 +6,7 @@ import winston from 'winston';
 import NodeCache from 'node-cache';
 import { DateTime } from 'luxon';
 import { AeSdk, toAettos, toAe, getAddressFromPriv, MemoryAccount, Node, isAddressValid } from '@aeternity/aepp-sdk/es/index.mjs';
+import cors from 'cors';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -64,6 +65,8 @@ await aeSdk.addAccount(
     { select: true },
 );
 const app = express();
+
+app.use(cors());
 
 // set up mustache templating
 app.engine('mustache', mustache());

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aeternity/aepp-sdk": "^12.1.3",
+        "cors": "^2.8.5",
         "express": "^4.17.1",
         "luxon": "^1.27.0",
         "mustache-express": "^1.3.0",
@@ -572,6 +573,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -1127,6 +1140,14 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/on-finished": {
@@ -2020,6 +2041,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cross-fetch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
@@ -2454,6 +2484,11 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
       "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "on-finished": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/aeternity/aepp-faucet-nodejs#readme",
   "dependencies": {
     "@aeternity/aepp-sdk": "^12.1.3",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "luxon": "^1.27.0",
     "mustache-express": "^1.3.0",


### PR DESCRIPTION
closes #13 

This PR adds CORS in order to support requests from client apps. No cors options are provided as the faucet is publicly available.

If you'd like to test it

1. run faucet
2. open browser console
3. execute the following script

```js
async function f(address){
const res = await fetch("http://localhost:5000/account/"+address,{
method:"POST"});
const json = await res.json();
console.log({json});
}

f('ak_24jE1QVk6qk5WED625efkXmmbxpi9XzEXpmBdvUZc3AmqZFaMo');
```

BEFORE CORS
![image](https://user-images.githubusercontent.com/45261205/195101840-83ce83ea-5dfe-41c4-b640-037eac336462.png)


AFTER CORS
![image](https://user-images.githubusercontent.com/45261205/195101695-1c998ffd-4e3e-436a-b90c-d67327de6dd2.png)
