### PR TITLE
ci: use non-deprecated version of release-please-action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
           release-type: node


### PR DESCRIPTION
> Warning: google-github-actions/release-please-action is deprecated, please use googleapis/release-please-action instead.

This PR is supported by the Æternity Foundation